### PR TITLE
Improve plan card layout in chat

### DIFF
--- a/frontend/src/components/agentic/ContextTimeline.tsx
+++ b/frontend/src/components/agentic/ContextTimeline.tsx
@@ -1,6 +1,6 @@
 // status: alpha
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import '../../styles/agentic/ContextTimeline.css';
 import { ContextCommitEntry } from '../../utils/agentic/PlanStore';
 
@@ -9,27 +9,68 @@ interface ContextTimelineProps {
 }
 
 const ContextTimeline: React.FC<ContextTimelineProps> = ({ commits }) => {
-  if (commits.length === 0) {
+  const ordered = useMemo(() => [...commits].slice().reverse(), [commits]);
+  const eventCount = ordered.length;
+
+  if (eventCount === 0) {
     return null;
   }
 
-  const ordered = [...commits].slice().reverse();
+  const getRelativeTime = (timestamp: number) => {
+    const now = Date.now();
+    const diffMs = now - timestamp;
+    const diffSeconds = Math.round(diffMs / 1000);
+    if (diffSeconds < 30) {
+      return 'just now';
+    }
+    if (diffSeconds < 90) {
+      return '1m ago';
+    }
+    const diffMinutes = Math.round(diffSeconds / 60);
+    if (diffMinutes < 60) {
+      return `${diffMinutes}m ago`;
+    }
+    const diffHours = Math.round(diffMinutes / 60);
+    if (diffHours < 24) {
+      return `${diffHours}h ago`;
+    }
+    const diffDays = Math.round(diffHours / 24);
+    return `${diffDays}d ago`;
+  };
 
   return (
     <section className="context-timeline" aria-label="Context timeline">
       <header className="context-timeline__header">
         <strong>Context Timeline</strong>
+        <span className="context-timeline__badge">{eventCount} updates</span>
       </header>
       <ul className="context-timeline__list">
-        {ordered.map((commit) => (
-          <li key={commit.newCtxId} className="context-timeline__item">
-            <div className="context-timeline__ctx">{commit.newCtxId}</div>
-            <div className="context-timeline__meta">
-              <span>from {commit.baseCtxId}</span>
-              <time dateTime={new Date(commit.timestamp).toISOString()}>{new Date(commit.timestamp).toLocaleTimeString()}</time>
-            </div>
-          </li>
-        ))}
+        {ordered.map((commit, index) => {
+          const timestamp = new Date(commit.timestamp);
+          const formattedTime = timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+          const relativeTime = getRelativeTime(commit.timestamp);
+
+          return (
+            <li key={`${commit.newCtxId}-${index}`} className="context-timeline__item">
+              <div className="context-timeline__item-header">
+                <span className="context-timeline__ctx">{commit.newCtxId}</span>
+                <div className="context-timeline__time-group">
+                  <time
+                    className="context-timeline__time"
+                    dateTime={timestamp.toISOString()}
+                    title={timestamp.toLocaleString()}
+                  >
+                    {formattedTime}
+                  </time>
+                  <span className="context-timeline__time-relative">{relativeTime}</span>
+                </div>
+              </div>
+              <div className="context-timeline__meta">
+                <span className="context-timeline__meta-label">from {commit.baseCtxId}</span>
+              </div>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/frontend/src/components/agentic/LLMMonitor.tsx
+++ b/frontend/src/components/agentic/LLMMonitor.tsx
@@ -1,6 +1,6 @@
 // status: alpha
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import '../../styles/agentic/LLMMonitor.css';
 import { ToolCallEntry } from '../../utils/agentic/PlanStore';
 
@@ -9,40 +9,51 @@ interface LLMMonitorProps {
 }
 
 const LLMMonitor: React.FC<LLMMonitorProps> = ({ calls }) => {
-  if (calls.length === 0) {
+  const ordered = useMemo(() => [...calls].slice().reverse(), [calls]);
+  const totalCalls = ordered.length;
+
+  if (totalCalls === 0) {
     return null;
   }
-
-  const ordered = [...calls].slice().reverse();
 
   return (
     <section className="llm-monitor" aria-label="Tool call monitor">
       <header className="llm-monitor__header">
         <strong>Tool Calls</strong>
+        <span className="llm-monitor__badge">{totalCalls} total</span>
       </header>
-      <table className="llm-monitor__table">
-        <thead>
-          <tr>
-            <th>Tool</th>
-            <th>Latency</th>
-            <th>Tokens</th>
-            <th>Cost</th>
-          </tr>
-        </thead>
-        <tbody>
-          {ordered.map((call) => (
-            <tr key={call.id}>
-              <td>
-                <div className="llm-monitor__tool">{call.tool}</div>
-                <div className="llm-monitor__provider">{call.provider || '—'}</div>
-              </td>
-              <td>{call.latencyMs} ms</td>
-              <td>{call.tokens ?? '—'}</td>
-              <td>{typeof call.cost === 'number' ? `$${call.cost.toFixed(4)}` : '—'}</td>
+      <div className="llm-monitor__table-wrapper">
+        <table className="llm-monitor__table">
+          <thead>
+            <tr>
+              <th scope="col">Tool</th>
+              <th scope="col">Latency</th>
+              <th scope="col">Tokens</th>
+              <th scope="col">Cost</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {ordered.map(call => {
+              const providerMeta = [call.provider, call.model].filter(Boolean).join(' Â· ');
+              const latencyLabel = `${call.latencyMs.toLocaleString()} ms`;
+              const tokenLabel = typeof call.tokens === 'number' ? call.tokens.toLocaleString() : '';
+              const costLabel = typeof call.cost === 'number' ? `$${call.cost.toFixed(4)}` : '';
+
+              return (
+                <tr key={call.id}>
+                  <td>
+                    <div className="llm-monitor__tool">{call.tool}</div>
+                    {providerMeta && <div className="llm-monitor__provider">{providerMeta}</div>}
+                  </td>
+                  <td className="llm-monitor__cell llm-monitor__cell--numeric">{latencyLabel}</td>
+                  <td className="llm-monitor__cell llm-monitor__cell--numeric">{tokenLabel}</td>
+                  <td className="llm-monitor__cell llm-monitor__cell--numeric">{costLabel}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 };

--- a/frontend/src/components/agentic/PlanBox.tsx
+++ b/frontend/src/components/agentic/PlanBox.tsx
@@ -11,15 +11,49 @@ interface PlanBoxProps {
   chatId: string;
 }
 
+const formatLabel = (value: string) =>
+  String(value)
+    .toLowerCase()
+    .split('_')
+    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
 const PlanBox: React.FC<PlanBoxProps> = ({ summary, tasks, chatId }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const ordered = [...tasks].sort((a, b) => a.taskId.localeCompare(b.taskId));
   const planStatus = (summary.plan as any)?.status || 'PENDING_APPROVAL';
+  const normalizedPlanStatus = String(planStatus).toLowerCase().replace(/[^a-z0-9_]/g, '-');
+  const planStatusLabel = formatLabel(planStatus);
   const isPending = planStatus === 'PENDING_APPROVAL';
   const isApproved = planStatus === 'APPROVED';
   const isDenied = planStatus === 'DENIED';
+
+  const fingerprint = summary.fingerprint || '';
+  const displayFingerprint = fingerprint ? fingerprint.slice(0, 12).toUpperCase() : '—';
+  const planName = (() => {
+    const rawName = (summary.plan as any)?.name;
+    if (typeof rawName === 'string' && rawName.trim().length > 0) {
+      return rawName.trim();
+    }
+    return 'Execution Plan';
+  })();
+  const planObjective = (() => {
+    const candidate = (summary.plan as any)?.objective || (summary.plan as any)?.description;
+    return typeof candidate === 'string' ? candidate.trim() : '';
+  })();
+
+  const totalTasks = ordered.length;
+  const completedTasks = ordered.filter(task => task.state === 'DONE').length;
+  const runningTasks = ordered.filter(task => task.state === 'RUNNING').length;
+  const queuedTasks = Math.max(totalTasks - completedTasks - runningTasks, 0);
+  const hasRenderedTasks = totalTasks > 0;
+
+  const previewEntries: Array<[string, any]> = summary.plan
+    ? Object.entries((summary.plan as any).tasks || {})
+    : [];
+  const hasPreviewEntries = isPending && previewEntries.length > 0;
 
   const handleApprove = async () => {
     setLoading(true);
@@ -48,19 +82,50 @@ const PlanBox: React.FC<PlanBoxProps> = ({ summary, tasks, chatId }) => {
   };
 
   return (
-    <section className={`plan-box plan-box--${planStatus.toLowerCase()}`} aria-label="Plan overview">
+    <section className={`plan-box plan-box--${normalizedPlanStatus}`} aria-label="Plan overview">
       <header className="plan-box__header">
-        <div>
-          <strong>Plan</strong>
-          <span className="plan-box__meta">{summary.planId}</span>
-          <span className={`plan-box__status plan-box__status--${planStatus.toLowerCase()}`}>
-            {planStatus.replace('_', ' ')}
-          </span>
+        <div className="plan-box__title">
+          <span className="plan-box__eyebrow">Plan</span>
+          <div className="plan-box__title-row">
+            <h3 className="plan-box__heading">{planName}</h3>
+            <span className={`plan-box__status plan-box__status--${normalizedPlanStatus}`}>
+              {planStatusLabel}
+            </span>
+          </div>
+          <div className="plan-box__meta">ID · {summary.planId}</div>
         </div>
         <div className="plan-box__fingerprint" title="Plan fingerprint">
-          {summary.fingerprint.slice(0, 8)}
+          <span className="plan-box__fingerprint-label">Fingerprint</span>
+          <span className="plan-box__fingerprint-value">{displayFingerprint}</span>
         </div>
       </header>
+
+      {planObjective && (
+        <p className="plan-box__objective">{planObjective}</p>
+      )}
+
+      {hasRenderedTasks && (
+        <div className="plan-box__stats">
+          <div className="plan-box__stat">
+            <span className="plan-box__stat-value">{totalTasks}</span>
+            <span className="plan-box__stat-label">Tasks</span>
+          </div>
+          <div className="plan-box__stat">
+            <span className="plan-box__stat-value">{runningTasks}</span>
+            <span className="plan-box__stat-label">In Flight</span>
+          </div>
+          <div className="plan-box__stat">
+            <span className="plan-box__stat-value">{completedTasks}</span>
+            <span className="plan-box__stat-label">Completed</span>
+          </div>
+          {queuedTasks > 0 && (
+            <div className="plan-box__stat">
+              <span className="plan-box__stat-value">{queuedTasks}</span>
+              <span className="plan-box__stat-label">Queued</span>
+            </div>
+          )}
+        </div>
+      )}
 
       {error && (
         <div className="plan-box__error">
@@ -79,14 +144,14 @@ const PlanBox: React.FC<PlanBoxProps> = ({ summary, tasks, chatId }) => {
               onClick={handleApprove}
               disabled={loading}
             >
-              {loading ? 'Approving...' : 'Accept'}
+              {loading ? 'Approving…' : 'Approve plan'}
             </button>
             <button
               className="plan-box__deny-btn"
               onClick={handleDeny}
               disabled={loading}
             >
-              {loading ? 'Denying...' : 'Deny'}
+              {loading ? 'Denying…' : 'Reject plan'}
             </button>
           </div>
         </div>
@@ -94,7 +159,7 @@ const PlanBox: React.FC<PlanBoxProps> = ({ summary, tasks, chatId }) => {
 
       {isApproved && (
         <div className="plan-box__status-message plan-box__status-message--approved">
-          Plan approved and executing...
+          Plan approved and executing…
         </div>
       )}
 
@@ -104,30 +169,80 @@ const PlanBox: React.FC<PlanBoxProps> = ({ summary, tasks, chatId }) => {
         </div>
       )}
 
-      <div className="plan-box__body">
-        {ordered.length === 0 && !isPending && (
-          <p className="plan-box__empty">Waiting for tasks&hellip;</p>
-        )}
-        {isPending && summary.plan && (
+      <div className={`plan-box__body ${hasRenderedTasks ? 'plan-box__body--has-tasks' : ''}`}>
+        {hasPreviewEntries && (
           <div className="plan-box__plan-preview">
-            <strong>Planned Tasks:</strong>
-            {Object.entries((summary.plan as any).tasks || {}).map(([taskId, task]: [string, any]) => (
-              <div key={taskId} className="plan-box__planned-task">
-                <span className="plan-box__planned-task-id">{taskId}</span>
-                <span className="plan-box__planned-task-tool">{task.tool}</span>
-              </div>
-            ))}
+            <div className="plan-box__plan-preview-header">
+              <span className="plan-box__plan-preview-title">Planned Tasks</span>
+              <span className="plan-box__plan-preview-subtitle">Review before approval</span>
+            </div>
+            <div className="plan-box__plan-preview-list">
+              {previewEntries.map(([taskId, task]) => {
+                const previewDescription = typeof task?.description === 'string'
+                  ? task.description
+                  : typeof task?.summary === 'string'
+                    ? task.summary
+                    : typeof task?.objective === 'string'
+                      ? task.objective
+                      : '';
+                const previewTool = typeof task?.tool === 'string' ? task.tool : '';
+                return (
+                  <div key={taskId} className="plan-box__planned-task">
+                    <div className="plan-box__planned-task-main">
+                      <span className="plan-box__planned-task-id">{taskId}</span>
+                      {previewDescription && (
+                        <p className="plan-box__planned-task-description">{previewDescription}</p>
+                      )}
+                    </div>
+                    {previewTool && (
+                      <span className="plan-box__planned-task-tool">{previewTool}</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
           </div>
         )}
-        {ordered.map((task) => (
-          <div key={`${task.taskId}-${task.attempt}`} className={`plan-box__task plan-box__task--${task.state.toLowerCase()}`}>
-            <div className="plan-box__task-header">
-              <span className="plan-box__task-id">{task.taskId}</span>
-              <span className="plan-box__task-state">{task.state}</span>
-            </div>
-            <div className="plan-box__task-attempt">Attempt {task.attempt}</div>
-          </div>
-        ))}
+
+        {hasRenderedTasks ? (
+          ordered.map(task => {
+            const taskStateLabel = formatLabel(task.state);
+            const taskStateClass = String(task.state).toLowerCase().replace(/[^a-z0-9_]/g, '-');
+            const taskTool = typeof task.payload?.tool === 'string'
+              ? task.payload.tool
+              : typeof task.payload?.metadata?.tool === 'string'
+                ? task.payload.metadata.tool
+                : undefined;
+            const taskDescription = typeof task.payload?.summary === 'string'
+              ? task.payload.summary
+              : typeof task.payload?.description === 'string'
+                ? task.payload.description
+                : undefined;
+
+            return (
+              <div
+                key={`${task.taskId}-${task.attempt}`}
+                className={`plan-box__task plan-box__task--${taskStateClass}`}
+              >
+                <div className="plan-box__task-header">
+                  <span className="plan-box__task-id">{task.taskId}</span>
+                  <span className="plan-box__task-state">{taskStateLabel}</span>
+                </div>
+                <div className="plan-box__task-meta">
+                  <span className="plan-box__task-attempt">Attempt {task.attempt}</span>
+                  {taskTool && <span className="plan-box__task-tool">{taskTool}</span>}
+                </div>
+                {taskDescription && (
+                  <p className="plan-box__task-description">{taskDescription}</p>
+                )}
+              </div>
+            );
+          })
+        ) : (
+          !isPending && (
+            <p className="plan-box__empty">Waiting for tasks…</p>
+          )
+        )}
       </div>
     </section>
   );

--- a/frontend/src/components/agentic/PlanMessage.tsx
+++ b/frontend/src/components/agentic/PlanMessage.tsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from 'react';
+import PlanBox from './PlanBox';
+import ContextTimeline from './ContextTimeline';
+import LLMMonitor from './LLMMonitor';
+import {
+  ContextCommitEntry,
+  PlanSummary,
+  TaskStateEntry,
+  ToolCallEntry
+} from '../../utils/agentic/PlanStore';
+import '../../styles/agentic/PlanMessage.css';
+
+interface PlanMessageProps {
+  summary: PlanSummary;
+  tasks: TaskStateEntry[];
+  commits: ContextCommitEntry[];
+  toolCalls: ToolCallEntry[];
+  chatId: string;
+}
+
+const PlanMessage: React.FC<PlanMessageProps> = ({
+  summary,
+  tasks,
+  commits,
+  toolCalls,
+  chatId
+}) => {
+  const normalizedStatus = useMemo(() => {
+    const rawStatus = (summary.plan as any)?.status || 'PENDING_APPROVAL';
+    return String(rawStatus).toLowerCase().replace(/[^a-z0-9_]/g, '-');
+  }, [summary.plan]);
+
+  const hasInsights = commits.length > 0 || toolCalls.length > 0;
+
+  return (
+    <div className={`agentic-plan-message agentic-plan-message--${normalizedStatus}`}>
+      <PlanBox summary={summary} tasks={tasks} chatId={chatId} />
+      {hasInsights && (
+        <div className="agentic-plan-message__grid">
+          {commits.length > 0 && <ContextTimeline commits={commits} />}
+          {toolCalls.length > 0 && <LLMMonitor calls={toolCalls} />}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PlanMessage;

--- a/frontend/src/components/chat/Chat.tsx
+++ b/frontend/src/components/chat/Chat.tsx
@@ -7,9 +7,7 @@ import ThinkBox from './ThinkBox';
 import RouterBox from './RouterBox';
 import MessageRenderer from '../message/MessageRenderer';
 import MessageWrapper from '../message/MessageWrapper';
-import PlanBox from '../agentic/PlanBox';
-import ContextTimeline from '../agentic/ContextTimeline';
-import LLMMonitor from '../agentic/LLMMonitor';
+import PlanMessage from '../agentic/PlanMessage';
 import { liveStore } from '../../utils/chat/LiveStore';
 import { chatHistoryCache } from '../../utils/chat/ChatHistoryCache';
 import { versionSwitchLoadingManager } from '../../utils/versioning/versionSwitchLoadingManager';
@@ -29,7 +27,6 @@ import '../../styles/chat/Chat.css';
 import '../../styles/chat/ThinkBox.css';
 import '../../styles/chat/RouterBox.css';
 import '../../styles/message/MessageRenderer.css';
-import '../../styles/agentic/Panels.css';
 import type { AttachedFile, Message } from '../../types/messages';
 
 const DUPLICATE_WINDOW_MS = 1000;
@@ -1265,18 +1262,31 @@ const Chat = React.memo(forwardRef<any, ChatProps>(({
   return (
     <>
       <div className="chat-messages">
-        {planSummary && (
-          <div className="agentic-panels">
-            <PlanBox summary={planSummary} tasks={planTasks} chatId={chatId || ''} />
-            <ContextTimeline commits={planCommits} />
-            <LLMMonitor calls={planToolCalls} />
-          </div>
-        )}
         <div className="messages-container" ref={messagesContainerRef}>
           {(needsBottomAnchor || (forceBottomDuringStreaming && canRenderOverlay)) && (
             <div className="spacer" style={{flex: '1 0 auto'}}></div>
           )}
           {messageListContent}
+
+          {planSummary && (
+            <MessageWrapper
+              key={`plan-${planSummary.planId}`}
+              messageId={`plan-${planSummary.planId}`}
+              messageRole="assistant"
+              messageContent="Plan overview"
+              className="assistant-message agentic-plan-message-wrapper"
+              currentChatId={chatId}
+              isTTSSupported={false}
+            >
+              <PlanMessage
+                summary={planSummary}
+                tasks={planTasks}
+                commits={planCommits}
+                toolCalls={planToolCalls}
+                chatId={chatId || ''}
+              />
+            </MessageWrapper>
+          )}
 
           {canRenderOverlay && (
             <div className="assistant-message">

--- a/frontend/src/styles/agentic/ContextTimeline.css
+++ b/frontend/src/styles/agentic/ContextTimeline.css
@@ -1,40 +1,170 @@
 .context-timeline {
-  background: #0f172a;
-  border: 1px solid rgba(148, 163, 184, 0.15);
-  border-radius: 12px;
-  padding: 12px;
-  margin-bottom: 12px;
+  --timeline-accent: var(--agentic-accent, #38bdf8);
+  --timeline-accent-glow: rgba(56, 189, 248, 0.45);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(9, 14, 25, 0.82), rgba(6, 10, 20, 0.68));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  color: #f8fafc;
+  overflow: hidden;
+  backdrop-filter: blur(12px);
+}
+
+.context-timeline::before {
+  content: '';
+  position: absolute;
+  inset: auto -40% -60% auto;
+  width: 240px;
+  height: 240px;
+  background: radial-gradient(circle at center, rgba(148, 163, 184, 0.16), transparent 70%);
+  opacity: 0.7;
+  pointer-events: none;
 }
 
 .context-timeline__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  z-index: 1;
+}
+
+.context-timeline__header strong {
+  font-size: 16px;
   font-weight: 600;
-  margin-bottom: 8px;
-  color: #e2e8f0;
+  letter-spacing: 0.04em;
+}
+
+.context-timeline__badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(8, 12, 24, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: rgba(226, 232, 240, 0.75);
 }
 
 .context-timeline__list {
   list-style: none;
-  padding: 0;
   margin: 0;
-  display: grid;
-  gap: 8px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: relative;
+  z-index: 1;
 }
 
 .context-timeline__item {
-  background: rgba(30, 41, 59, 0.8);
-  border-radius: 8px;
-  padding: 8px;
-  border: 1px solid rgba(148, 163, 184, 0.1);
+  position: relative;
+  padding-left: 32px;
+}
+
+.context-timeline__item::before {
+  content: '';
+  position: absolute;
+  left: 12px;
+  top: 2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--timeline-accent);
+  box-shadow: 0 0 16px var(--timeline-accent-glow);
+}
+
+.context-timeline__item::after {
+  content: '';
+  position: absolute;
+  left: 16px;
+  top: 14px;
+  bottom: -14px;
+  width: 2px;
+  background: linear-gradient(to bottom, rgba(148, 163, 184, 0.28), transparent 80%);
+}
+
+.context-timeline__item:last-child::after {
+  display: none;
+}
+
+.context-timeline__item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .context-timeline__ctx {
-  font-weight: 500;
-  color: #bae6fd;
+  font-weight: 600;
+  font-size: 14px;
+  color: #f8fafc;
+}
+
+.context-timeline__time-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.context-timeline__time {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.context-timeline__time-relative {
+  font-size: 11px;
+  color: rgba(226, 232, 240, 0.52);
 }
 
 .context-timeline__meta {
+  margin-top: 8px;
   font-size: 12px;
-  color: rgba(148, 163, 184, 0.8);
-  display: flex;
-  justify-content: space-between;
+  color: rgba(226, 232, 240, 0.62);
+}
+
+.context-timeline__meta-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 640px) {
+  .context-timeline {
+    padding: 18px;
+  }
+
+  .context-timeline__item {
+    padding-left: 28px;
+  }
+
+  .context-timeline__item::before {
+    left: 10px;
+  }
+
+  .context-timeline__item::after {
+    left: 14px;
+  }
+
+  .context-timeline__item-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .context-timeline__time-group {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+  }
 }

--- a/frontend/src/styles/agentic/LLMMonitor.css
+++ b/frontend/src/styles/agentic/LLMMonitor.css
@@ -1,42 +1,120 @@
 .llm-monitor {
-  background: #0f172a;
-  border: 1px solid rgba(148, 163, 184, 0.15);
-  border-radius: 12px;
-  padding: 12px;
+  --monitor-accent: var(--agentic-accent, #38bdf8);
+  --monitor-accent-glow: var(--agentic-accent-glow, rgba(56, 189, 248, 0.45));
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(8, 12, 24, 0.85), rgba(4, 9, 20, 0.68));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  color: #f8fafc;
+  overflow: hidden;
+  backdrop-filter: blur(12px);
+}
+
+.llm-monitor::before {
+  content: '';
+  position: absolute;
+  inset: -40% auto auto -30%;
+  width: 240px;
+  height: 240px;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.14), transparent 70%);
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 .llm-monitor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  z-index: 1;
+}
+
+.llm-monitor__header strong {
+  font-size: 16px;
   font-weight: 600;
-  margin-bottom: 8px;
-  color: #e2e8f0;
+  letter-spacing: 0.04em;
+}
+
+.llm-monitor__badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(8, 12, 24, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.llm-monitor__table-wrapper {
+  position: relative;
+  z-index: 1;
+  overflow-x: auto;
 }
 
 .llm-monitor__table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  min-width: 420px;
 }
 
-.llm-monitor__table th,
-.llm-monitor__table td {
+.llm-monitor__table thead th {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.6);
   text-align: left;
-  padding: 6px 8px;
-  color: rgba(226, 232, 240, 0.9);
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
-.llm-monitor__table tbody tr:nth-child(even) {
-  background: rgba(15, 23, 42, 0.6);
+.llm-monitor__table tbody tr {
+  transition: background 0.2s ease;
 }
 
-.llm-monitor__table tbody tr:nth-child(odd) {
-  background: rgba(30, 41, 59, 0.6);
+.llm-monitor__table tbody tr:hover {
+  background: rgba(12, 18, 34, 0.68);
+}
+
+.llm-monitor__table td {
+  padding: 12px;
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.82);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.llm-monitor__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.llm-monitor__cell--numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: rgba(226, 232, 240, 0.75);
 }
 
 .llm-monitor__tool {
-  font-weight: 500;
+  font-weight: 600;
+  color: #f8fafc;
 }
 
 .llm-monitor__provider {
+  margin-top: 4px;
   font-size: 12px;
-  color: rgba(148, 163, 184, 0.7);
+  color: rgba(226, 232, 240, 0.6);
+}
+
+@media (max-width: 640px) {
+  .llm-monitor {
+    padding: 18px;
+  }
+
+  .llm-monitor__table {
+    min-width: 360px;
+  }
 }

--- a/frontend/src/styles/agentic/PlanBox.css
+++ b/frontend/src/styles/agentic/PlanBox.css
@@ -1,250 +1,578 @@
 .plan-box {
-  background: #0f172a;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 12px;
-  padding: 12px;
-  margin-bottom: 12px;
-  color: #e2e8f0;
+  --plan-accent: #38bdf8;
+  --plan-accent-soft: rgba(56, 189, 248, 0.2);
+  --plan-accent-strong: rgba(56, 189, 248, 0.45);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.94), rgba(12, 18, 34, 0.72));
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.48), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  color: #f8fafc;
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+}
+
+.plan-box::before {
+  content: '';
+  position: absolute;
+  top: -40%;
+  right: -40%;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle at center, var(--plan-accent-soft), transparent 65%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.plan-box::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  pointer-events: none;
+}
+
+.plan-box--pending_approval {
+  --plan-accent: #fbbf24;
+  --plan-accent-soft: rgba(251, 191, 36, 0.24);
+  --plan-accent-strong: rgba(251, 191, 36, 0.48);
+}
+
+.plan-box--approved,
+.plan-box--completed {
+  --plan-accent: #34d399;
+  --plan-accent-soft: rgba(52, 211, 153, 0.22);
+  --plan-accent-strong: rgba(52, 211, 153, 0.48);
+}
+
+.plan-box--denied {
+  --plan-accent: #fb7185;
+  --plan-accent-soft: rgba(251, 113, 133, 0.22);
+  --plan-accent-strong: rgba(251, 113, 133, 0.48);
+}
+
+.plan-box--running,
+.plan-box--executing,
+.plan-box--in_progress {
+  --plan-accent: #38bdf8;
+  --plan-accent-soft: rgba(56, 189, 248, 0.22);
+  --plan-accent-strong: rgba(56, 189, 248, 0.48);
 }
 
 .plan-box__header {
+  position: relative;
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: 8px;
+  align-items: flex-start;
+  gap: 18px;
+  z-index: 1;
 }
 
-.plan-box__meta {
-  margin-left: 8px;
-  font-size: 12px;
-  color: rgba(148, 163, 184, 0.8);
-}
-
-.plan-box__fingerprint {
-  font-size: 12px;
-  color: rgba(148, 163, 184, 0.7);
-}
-
-.plan-box__body {
-  display: grid;
+.plan-box__title {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
 }
 
+.plan-box__eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.62);
+}
+
+.plan-box__title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.plan-box__heading {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.plan-box__meta {
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.52);
+}
+
+.plan-box__fingerprint {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.55);
+}
+
+.plan-box__fingerprint-label {
+  opacity: 0.7;
+}
+
+.plan-box__fingerprint-value {
+  font-family: 'SFMono-Regular', 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 14px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(8, 12, 24, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  color: #f8fafc;
+}
+
+.plan-box__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(8, 12, 24, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--plan-accent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.plan-box__status::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--plan-accent);
+  box-shadow: 0 0 12px var(--plan-accent-strong);
+}
+
+.plan-box__status--pending_approval {
+  border-color: rgba(251, 191, 36, 0.32);
+}
+
+.plan-box__status--approved,
+.plan-box__status--completed {
+  border-color: rgba(52, 211, 153, 0.28);
+}
+
+.plan-box__status--denied {
+  border-color: rgba(251, 113, 133, 0.32);
+}
+
+.plan-box__objective {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.78);
+  z-index: 1;
+}
+
+.plan-box__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  z-index: 1;
+}
+
+.plan-box__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(9, 14, 25, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.plan-box__stat-value {
+  font-size: 20px;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.plan-box__stat-label {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.58);
+}
+
+.plan-box__error {
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(251, 113, 133, 0.14);
+  border: 1px solid rgba(251, 113, 133, 0.4);
+  color: #fecaca;
+  font-size: 13px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.plan-box__approval {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  z-index: 1;
+}
+
+.plan-box__approval-message {
+  font-size: 14px;
+  font-weight: 500;
+  color: #facc15;
+}
+
+.plan-box__approval-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.plan-box__approve-btn,
+.plan-box__deny-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 20px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.plan-box__approve-btn {
+  background: linear-gradient(135deg, #34d399, #22c55e);
+  color: #052e16;
+  box-shadow: 0 12px 24px rgba(34, 197, 94, 0.35);
+}
+
+.plan-box__approve-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(34, 197, 94, 0.45);
+}
+
+.plan-box__deny-btn {
+  background: linear-gradient(135deg, #fb7185, #f43f5e);
+  color: #3f0210;
+  box-shadow: 0 12px 24px rgba(244, 63, 94, 0.35);
+}
+
+.plan-box__deny-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(244, 63, 94, 0.45);
+}
+
+.plan-box__approve-btn:disabled,
+.plan-box__deny-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.plan-box__status-message {
+  padding: 14px 16px;
+  border-radius: 16px;
+  font-size: 14px;
+  font-weight: 500;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.plan-box__status-message--approved {
+  background: rgba(52, 211, 153, 0.12);
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  color: #34d399;
+}
+
+.plan-box__status-message--denied {
+  background: rgba(251, 113, 133, 0.14);
+  border: 1px solid rgba(251, 113, 133, 0.4);
+  color: #fb7185;
+}
+
+.plan-box__body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  z-index: 1;
+}
+
+.plan-box__body--has-tasks::before {
+  content: '';
+  position: absolute;
+  left: 18px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: linear-gradient(to bottom, var(--plan-accent-soft), transparent 85%);
+  opacity: 0.7;
+}
+
+.plan-box__plan-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(9, 14, 25, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.plan-box__plan-preview-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.plan-box__plan-preview-title {
+  font-size: 13px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.plan-box__plan-preview-subtitle {
+  font-size: 12px;
+  color: rgba(226, 232, 240, 0.55);
+}
+
+.plan-box__plan-preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.plan-box__planned-task {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(8, 13, 26, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.plan-box__planned-task-main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.plan-box__planned-task-id {
+  font-weight: 600;
+  font-size: 14px;
+  color: #f8fafc;
+}
+
+.plan-box__planned-task-description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.plan-box__planned-task-tool {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: rgba(56, 189, 248, 0.16);
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  color: #38bdf8;
+  font-weight: 600;
+}
+
 .plan-box__task {
-  background: rgba(30, 41, 59, 0.8);
-  border-radius: 8px;
-  padding: 10px;
-  border: 1px solid transparent;
+  position: relative;
+  padding: 18px 18px 18px 40px;
+  border-radius: 18px;
+  background: rgba(5, 10, 21, 0.76);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+
+.plan-box__task::before {
+  content: '';
+  position: absolute;
+  left: 16px;
+  top: 24px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--task-accent, var(--plan-accent));
+  box-shadow: 0 0 16px var(--task-glow, var(--plan-accent-strong));
 }
 
 .plan-box__task--running {
-  border-color: #38bdf8;
+  --task-accent: #38bdf8;
+  --task-glow: rgba(56, 189, 248, 0.6);
+  border-color: rgba(56, 189, 248, 0.35);
+  background: rgba(9, 20, 36, 0.82);
 }
 
-.plan-box__task--done {
-  border-color: #34d399;
+.plan-box__task--done,
+.plan-box__task--completed {
+  --task-accent: #34d399;
+  --task-glow: rgba(52, 211, 153, 0.55);
+  border-color: rgba(52, 211, 153, 0.32);
+  background: rgba(10, 28, 22, 0.78);
 }
 
 .plan-box__task--failed {
-  border-color: #f87171;
+  --task-accent: #fb7185;
+  --task-glow: rgba(251, 113, 133, 0.55);
+  border-color: rgba(251, 113, 133, 0.32);
+  background: rgba(36, 12, 20, 0.78);
+}
+
+.plan-box__task--waiting,
+.plan-box__task--pending,
+.plan-box__task--queued {
+  --task-accent: #fbbf24;
+  --task-glow: rgba(251, 191, 36, 0.5);
+  border-color: rgba(251, 191, 36, 0.32);
+  background: rgba(34, 24, 10, 0.78);
 }
 
 .plan-box__task-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  gap: 12px;
 }
 
 .plan-box__task-id {
   font-weight: 600;
+  font-size: 15px;
+  color: #f8fafc;
 }
 
 .plan-box__task-state {
   font-size: 12px;
-  text-transform: uppercase;
+  font-weight: 600;
   letter-spacing: 0.08em;
-  color: rgba(148, 163, 184, 0.9);
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.68);
+}
+
+.plan-box__task-meta {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+  color: rgba(226, 232, 240, 0.65);
 }
 
 .plan-box__task-attempt {
-  margin-top: 4px;
-  font-size: 12px;
-  color: rgba(148, 163, 184, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+}
+
+.plan-box__task-tool {
+  padding: 6px 12px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  background: rgba(56, 189, 248, 0.16);
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  color: #38bdf8;
+}
+
+.plan-box__task--done .plan-box__task-tool,
+.plan-box__task--completed .plan-box__task-tool {
+  background: rgba(52, 211, 153, 0.16);
+  border-color: rgba(52, 211, 153, 0.28);
+  color: #34d399;
+}
+
+.plan-box__task--failed .plan-box__task-tool {
+  background: rgba(251, 113, 133, 0.16);
+  border-color: rgba(251, 113, 133, 0.28);
+  color: #fb7185;
+}
+
+.plan-box__task--waiting .plan-box__task-tool,
+.plan-box__task--pending .plan-box__task-tool,
+.plan-box__task--queued .plan-box__task-tool {
+  background: rgba(251, 191, 36, 0.16);
+  border-color: rgba(251, 191, 36, 0.28);
+  color: #fbbf24;
+}
+
+.plan-box__task-description {
+  margin: 10px 0 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: rgba(226, 232, 240, 0.72);
 }
 
 .plan-box__empty {
   margin: 0;
   font-size: 13px;
-  color: rgba(148, 163, 184, 0.7);
+  color: rgba(226, 232, 240, 0.6);
 }
 
-/* Plan status styling */
-.plan-box--pending_approval {
-  border-color: #f59e0b;
+@media (max-width: 768px) {
+  .plan-box {
+    padding: 20px;
+    border-radius: 18px;
+  }
+
+  .plan-box__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .plan-box__fingerprint {
+    align-items: flex-start;
+  }
+
+  .plan-box__stats {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
 }
 
-.plan-box--approved {
-  border-color: #34d399;
-}
+@media (max-width: 640px) {
+  .plan-box__task {
+    padding: 16px 16px 16px 32px;
+  }
 
-.plan-box--denied {
-  border-color: #f87171;
-}
+  .plan-box__task::before {
+    left: 12px;
+  }
 
-.plan-box__status {
-  margin-left: 8px;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 11px;
-  text-transform: uppercase;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-}
-
-.plan-box__status--pending_approval {
-  background: rgba(245, 158, 11, 0.2);
-  color: #f59e0b;
-}
-
-.plan-box__status--approved {
-  background: rgba(52, 211, 153, 0.2);
-  color: #34d399;
-}
-
-.plan-box__status--denied {
-  background: rgba(248, 113, 113, 0.2);
-  color: #f87171;
-}
-
-/* Approval section */
-.plan-box__approval {
-  margin: 12px 0;
-  padding: 12px;
-  background: rgba(245, 158, 11, 0.1);
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  border-radius: 8px;
-}
-
-.plan-box__approval-message {
-  margin-bottom: 12px;
-  font-size: 14px;
-  color: #f59e0b;
-  font-weight: 500;
-}
-
-.plan-box__approval-buttons {
-  display: flex;
-  gap: 8px;
-}
-
-.plan-box__approve-btn,
-.plan-box__deny-btn {
-  padding: 8px 16px;
-  border: none;
-  border-radius: 6px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.plan-box__approve-btn {
-  background: #34d399;
-  color: #0f172a;
-}
-
-.plan-box__approve-btn:hover:not(:disabled) {
-  background: #10b981;
-}
-
-.plan-box__approve-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.plan-box__deny-btn {
-  background: #f87171;
-  color: #0f172a;
-}
-
-.plan-box__deny-btn:hover:not(:disabled) {
-  background: #ef4444;
-}
-
-.plan-box__deny-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-/* Status messages */
-.plan-box__status-message {
-  margin: 12px 0;
-  padding: 10px 12px;
-  border-radius: 6px;
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.plan-box__status-message--approved {
-  background: rgba(52, 211, 153, 0.1);
-  border: 1px solid rgba(52, 211, 153, 0.3);
-  color: #34d399;
-}
-
-.plan-box__status-message--denied {
-  background: rgba(248, 113, 113, 0.1);
-  border: 1px solid rgba(248, 113, 113, 0.3);
-  color: #f87171;
-}
-
-/* Error message */
-.plan-box__error {
-  margin: 8px 0;
-  padding: 8px 12px;
-  background: rgba(248, 113, 113, 0.1);
-  border: 1px solid rgba(248, 113, 113, 0.3);
-  border-radius: 6px;
-  color: #f87171;
-  font-size: 13px;
-}
-
-/* Plan preview */
-.plan-box__plan-preview {
-  margin: 12px 0;
-  padding: 12px;
-  background: rgba(30, 41, 59, 0.8);
-  border-radius: 8px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.plan-box__plan-preview strong {
-  display: block;
-  margin-bottom: 8px;
-  color: #e2e8f0;
-  font-size: 13px;
-}
-
-.plan-box__planned-task {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 6px 0;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
-}
-
-.plan-box__planned-task:last-child {
-  border-bottom: none;
-}
-
-.plan-box__planned-task-id {
-  font-weight: 600;
-  color: #e2e8f0;
-}
-
-.plan-box__planned-task-tool {
-  font-size: 12px;
-  color: rgba(148, 163, 184, 0.8);
-  background: rgba(30, 41, 59, 0.8);
-  padding: 2px 6px;
-  border-radius: 4px;
+  .plan-box__body--has-tasks::before {
+    left: 14px;
+  }
 }

--- a/frontend/src/styles/agentic/PlanMessage.css
+++ b/frontend/src/styles/agentic/PlanMessage.css
@@ -1,0 +1,70 @@
+.agentic-plan-message-wrapper {
+  margin-top: 16px;
+}
+
+.agentic-plan-message-wrapper .message-controls,
+.agentic-plan-message-wrapper .message-version-switcher {
+  display: none !important;
+}
+
+.agentic-plan-message-wrapper .message-content,
+.agentic-plan-message-wrapper .message-content > * {
+  width: 100%;
+}
+
+.agentic-plan-message {
+  --agentic-accent: #38bdf8;
+  --agentic-accent-glow: rgba(56, 189, 248, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  width: 100%;
+}
+
+.agentic-plan-message--pending_approval {
+  --agentic-accent: #fbbf24;
+  --agentic-accent-glow: rgba(251, 191, 36, 0.45);
+}
+
+.agentic-plan-message--approved,
+.agentic-plan-message--completed {
+  --agentic-accent: #34d399;
+  --agentic-accent-glow: rgba(52, 211, 153, 0.45);
+}
+
+.agentic-plan-message--denied {
+  --agentic-accent: #fb7185;
+  --agentic-accent-glow: rgba(251, 113, 133, 0.45);
+}
+
+.agentic-plan-message--running,
+.agentic-plan-message--executing,
+.agentic-plan-message--in_progress {
+  --agentic-accent: #38bdf8;
+  --agentic-accent-glow: rgba(56, 189, 248, 0.45);
+}
+
+.agentic-plan-message .context-timeline,
+.agentic-plan-message .llm-monitor {
+  --timeline-accent: var(--agentic-accent);
+  --timeline-accent-glow: var(--agentic-accent-glow);
+  --monitor-accent: var(--agentic-accent);
+  --monitor-accent-glow: var(--agentic-accent-glow);
+}
+
+.agentic-plan-message__grid {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 768px) {
+  .agentic-plan-message__grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .agentic-plan-message-wrapper {
+    margin-top: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- move the plan approval UI into the message stream with a dedicated plan message wrapper component
- redesign the plan card, context timeline, and tool monitor with modern dark styling and richer status details
- add shared styling hooks so plan accents stay consistent across supporting panels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da5d3f204c8324bb1486178d8b0169