### PR TITLE
Optimize backend startup housekeeping and suppress noisy warnings

### DIFF
--- a/backend/file_utils/markdown_processor.py
+++ b/backend/file_utils/markdown_processor.py
@@ -1,28 +1,46 @@
 # status: complete
 
 from pathlib import Path
-from typing import Dict, Any
+from threading import Lock
+from typing import Dict, Any, Optional
 from utils.logger import get_logger
 from utils.db_utils import db
 from markitdown import MarkItDown
 
 logger = get_logger(__name__)
 
+_filespace_lock = Lock()
+_filespace_path: Optional[Path] = None
+_filespace_logged = False
+
+
 def setup_filespace():
     """Create the files folder in the data directory if it doesn't exist."""
+    global _filespace_path, _filespace_logged
+
     try:
-        backend_dir = Path(__file__).parent.parent
-        project_root = backend_dir.parent
-        data_dir = project_root / "data"
-        files_dir = data_dir / "files"
-        md_ver_dir = files_dir / "md_ver"
-        
-        files_dir.mkdir(parents=True, exist_ok=True)
-        md_ver_dir.mkdir(parents=True, exist_ok=True)
-        
-        logger.info(f"Files directories initialized at: {files_dir}")
+        should_log = False
+        with _filespace_lock:
+            if _filespace_path is not None and _filespace_path.exists():
+                return str(_filespace_path)
+
+            backend_dir = Path(__file__).parent.parent
+            project_root = backend_dir.parent
+            data_dir = project_root / "data"
+            files_dir = data_dir / "files"
+            md_ver_dir = files_dir / "md_ver"
+
+            files_dir.mkdir(parents=True, exist_ok=True)
+            md_ver_dir.mkdir(parents=True, exist_ok=True)
+
+            should_log = not _filespace_logged
+            _filespace_logged = True
+            _filespace_path = files_dir
+
+        if should_log:
+            logger.info(f"Files directories initialized at: {files_dir}")
         return str(files_dir)
-    
+
     except Exception as e:
         logger.error(f"Error setting up file space: {str(e)}")
         raise


### PR DESCRIPTION
## Summary
- add cached startup housekeeping in the Flask entrypoint so expensive file syncs and chat resets only run once per process
- suppress noisy dependency warnings and reuse filesystem setup to reduce duplicate log spam
- make filespace creation thread-safe and log it only on first invocation to speed up and quiet repeated imports

## Testing
- pytest backend/tests *(fails: expected error message wording and external HuggingFace download require network access)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdc10c6608324a4870cb0aa5b05a8